### PR TITLE
🩹 Fix Sonarqube widgets

### DIFF
--- a/content/sonar/widgets/project-metrics/script.js
+++ b/content/sonar/widgets/project-metrics/script.js
@@ -19,7 +19,7 @@ function run() {
 	data.results = [];
 	
 	var response = JSON.parse(
-					Packages.get(WIDGET_CONFIG_SONAR_URL + "/sonar/api/measures/component?componentKey=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
+					Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/measures/component?component=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
 					"Authorization", "Basic " + Packages.btoa(WIDGET_CONFIG_SONAR_TOKEN + ":")));
 
 	if (response && response.component && response.component.measures && response.component.measures.length > 0) {

--- a/content/sonar/widgets/projects-activity-by-analyse/script.js
+++ b/content/sonar/widgets/projects-activity-by-analyse/script.js
@@ -38,7 +38,7 @@ function run() {
 	projectsNamesOrKeys.forEach(function(projectNameOrKey) {
 		var projects = [];
 		
-		var response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/sonar/api/components/search?" 
+		var response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/components/search?" 
 						+ "qualifiers=TRK"
 						+ "&q=" + projectNameOrKey
 						+ "&ps=" + pageSize
@@ -51,7 +51,7 @@ function run() {
 			while (response.paging.total > response.paging.pageIndex * response.paging.pageSize) {
 				projectPage++;
 				
-				response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/sonar/api/components/search?"
+				response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/components/search?"
 							+ "qualifiers=TRK"
 							+ "&q=" + projectNameOrKey
 							+ "&ps=" + pageSize 
@@ -66,7 +66,7 @@ function run() {
 					projectsAndAnalysesQuantity[projectNameOrKey] = 0;
 				}
 				
-				var projectAnalysesURL = WIDGET_CONFIG_SONAR_URL + "/sonar/api/project_analyses/search?project=" + project.key
+				var projectAnalysesURL = WIDGET_CONFIG_SONAR_URL + "/api/project_analyses/search?project=" + project.key
 											+ "&ps" + pageSize + "&p=1";
 				
 				if (data.fromDate) {


### PR DESCRIPTION
Sonarqube API calls are broken.

Tested with Sonarqube 7.9 and Sonarqube 8.9 and this change is working perfectly well :)

Not tested with Sonarqube 9 yet, as it's not yet the LTS