### PR TITLE
fix: gitlab roles distribution - pagination

### DIFF
--- a/content/gitlab/widgets/user-roles-project-distribution/content.html
+++ b/content/gitlab/widgets/user-roles-project-distribution/content.html
@@ -15,14 +15,14 @@
             $("#chart-{{SURI_INSTANCE_ID}}").height($(".widget-{{SURI_INSTANCE_ID}}").height()-130);
             $("#chart-{{SURI_INSTANCE_ID}}").width($(".widget-{{SURI_INSTANCE_ID}}").width()-40);
             var ctx = document.getElementById("chart-{{SURI_INSTANCE_ID}}").getContext('2d');
-			
+
             var minimalAccess = '{{{minimalAccess}}}';
             var guest = '{{{guest}}}';
             var reporter = '{{{reporter}}}';
-            var developper = '{{{developper}}}';
+            var developer = '{{{developer}}}';
             var maintainer = '{{{maintainer}}}';
             var owner = '{{{owner}}}';
-			
+
             var chart = new Chart(ctx, {
                 // The type of chart we want to create
                 type: 'pie',
@@ -32,14 +32,14 @@
                         'Minimal access',
                         'Guest',
                         'Reporter',
-                        'Developper',
+                        'Developer',
                         'Maintainer',
                         'Owner'
                     ],
                     datasets: [{
                         borderColor: ['#607D8B','#607D8B','#607D8B','#607D8B','#607D8B','#607D8B'],
                         backgroundColor: ['#599B34','#9B0120','#6ab38c','#b36da5','#929B00','#aeadb3'],
-                        data: [minimalAccess,guest,reporter,developper,maintainer,owner]
+                        data: [minimalAccess,guest,reporter,developer,maintainer,owner]
                     }],
                     borderWidth: 1
                 },


### PR DESCRIPTION
While playing a bit with all the widgets, I noticed an error on the GitLab roles distribution widget. Pagination was not handled properly, and thus only 20 members max were returned

![image](https://user-images.githubusercontent.com/55134804/185386815-429abaf5-58e8-4252-9cf1-77371975b4d5.png)

It's now fixed with this PR

![image](https://user-images.githubusercontent.com/55134804/185386855-4f8f0f3c-6392-4c71-9a21-e29b08f12ddb.png)

