### PR TITLE
feat: improve gitlab pipeline status

### DIFF
--- a/content/gitlab/widgets/pipeline-status/content.html
+++ b/content/gitlab/widgets/pipeline-status/content.html
@@ -1,10 +1,13 @@
 <a href="{{url}}" class="link" target="_blank">
 	<div class="fullwidget {{status}}">
-		<i class="fa-fix fa 
-		{{#success}}fa-thumbs-up{{/success}} 
-		{{#failed}}fa-thumbs-down{{/failed}} 
-		{{#running}}fa-running{{/running}} 
-		{{#otherStatus}}fa-exclamation-triangle{{/otherStatus}} 
+		<i class="fa-fix fa
+		{{#success}}fa-thumbs-up{{/success}}
+		{{#warning}}fa-exclamation-triangle{{/warning}}
+		{{#failed}}fa-thumbs-down{{/failed}}
+		{{#running}}fa-running{{/running}}
+		{{#canceled}}fa-ban{{/canceled}}
+		{{#skipped}}fa-angle-double-right{{/skipped}}
+		{{#otherStatus}}fa-exclamation-triangle{{/otherStatus}}
 		icon-background icon-background-opacity"></i>
 
 		<div class="grid-stack-item-content-inner">
@@ -14,10 +17,18 @@
 			<p class="value">
 				<i class="fa fa-code-branch"></i> {{branch}}
 			</p>
-			<h2 class="title">{{status}}</h2>
+			<h2 class="title">
+				{{status}}
+				{{#showFailedJobs}}
+				<p class="failed-jobs">
+					Jobs {{failed_jobs}} failed
+				</p>
+				{{/showFailedJobs}}
+			</h2>
 			<p class="time-value">
 				<i class="fa fa-calendar-alt"></i> Created the {{createdAt}}
 			</p>
+			{{^hideTimeTable}}
 			<table class="time-table">
 				<tr>
 					<td>
@@ -32,6 +43,7 @@
 					</td>
 				</tr>
 			</table>
+			{{/hideTimeTable}}
 			<p class="value user-value">
 				<i class="fa fa-user-alt"></i> {{name}} ({{username}})
 			</p>

--- a/content/gitlab/widgets/pipeline-status/params.yml
+++ b/content/gitlab/widgets/pipeline-status/params.yml
@@ -11,3 +11,15 @@ widgetParams:
     type: TEXT
     usageExample: 'dev'
     required: false
+  -
+    name: HIDE_TIMETABLE
+    description: 'Hide timetable (duration + queued time)'
+    type: BOOLEAN
+    defaultValue: false
+    required: false
+  -
+    name: SHOW_FAILED_JOBS
+    description: 'Show failed jobs'
+    type: BOOLEAN
+    defaultValue: false
+    required: false

--- a/content/gitlab/widgets/pipeline-status/script.js
+++ b/content/gitlab/widgets/pipeline-status/script.js
@@ -20,49 +20,70 @@ function run() {
 	data.project = JSON.parse(
 		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
-	var url = WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines?per_page=100&page=1";
-	
+	var url = WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines";
+
 	if (SURI_PROJECT_BRANCH) {
-		url += "&ref=" + SURI_PROJECT_BRANCH;
+		url += "?ref=" + SURI_PROJECT_BRANCH;
 	}
-	
+
 	var pipelines = JSON.parse(Packages.get(url, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-	
+
 	if (pipelines && pipelines.length > 0) {
-		data.status = pipelines[0].status;
-		
 		var pipeline = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines/" + pipelines[0].id + "?per_page=100&page=1", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-	
+			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines/" + pipelines[0].id, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+
+		data.status = pipeline.detailed_status.group;
 		data.name = pipeline.user.name;
 		data.username = pipeline.user.username;
 		data.branch = pipeline.ref;
 		data.url = pipeline.web_url;
 		data.createdAt = formatDate(pipeline.created_at);
-		
-		if (pipeline.duration) {
-            data.duration = secondsToDuration(pipeline.duration);
-        } else {
-			data.duration = 'N/A';
-		}
-		
-		if (pipeline.started_at) {
-			data.waitingTimeBeforeStarting = secondsToDuration((new Date(pipeline.started_at).getTime() - new Date(pipeline.created_at).getTime()) / 1000);
+
+		if (HIDE_TIMETABLE && HIDE_TIMETABLE === 'true') {
+			data.hideTimeTable = HIDE_TIMETABLE;
 		} else {
-			data.waitingTimeBeforeStarting = secondsToDuration((new Date().getTime() - new Date(pipeline.created_at).getTime()) / 1000) + (' (not started yet)');
+			if (pipeline.duration) {
+				data.duration = secondsToDuration(pipeline.duration);
+			} else {
+				data.duration = 'N/A';
+			}
+			if (pipeline.started_at) {
+				data.waitingTimeBeforeStarting = secondsToDuration((new Date(pipeline.started_at).getTime() - new Date(pipeline.created_at).getTime()) / 1000);
+			} else {
+				data.waitingTimeBeforeStarting = secondsToDuration((new Date().getTime() - new Date(pipeline.created_at).getTime()) / 1000) + (' (not started yet)');
+			}
 		}
-		
+
+		if (SHOW_FAILED_JOBS && SHOW_FAILED_JOBS === 'true') {
+			data.showFailedJobs = SHOW_FAILED_JOBS;
+			if (data.status === 'success-with-warnings' || data.status === 'failed') {
+				var failed_jobs = JSON.parse(
+					Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines/" + pipeline.id + "/jobs?scope=failed&per_page=100&page=1", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+					data.failed_jobs = "";
+				for (var i = 0; i < failed_jobs.length; i++) {
+					data.failed_jobs = data.failed_jobs + failed_jobs[i].name + ", ";
+				}
+				data.failed_jobs = data.failed_jobs.substring(0, data.failed_jobs.length - 2);
+			}
+		}
+
 		if (data.status === 'success') {
 			data.success = true;
+		} else if (data.status === 'success-with-warnings') {
+			data.warning = true;
 		} else if (data.status === 'failed') {
 			data.failed = true;
 		} else if (data.status === 'running') {
 			data.running = true;
+		} else if (data.status === 'canceled') {
+			data.canceled = true;
+		} else if (data.status === 'skipped') {
+			data.skipped = true;
 		} else {
 			data.otherStatus = true;
 		}
 	}
-		
+
 	return JSON.stringify(data);
 }
 
@@ -82,11 +103,11 @@ function formatDate(date) {
     var hours = new Date(date).getHours() < 10 ? "0" + new Date(date).getHours() : new Date(date).getHours();
     var minutes = new Date(date).getMinutes() < 10 ? "0" + new Date(date).getMinutes() : new Date(date).getMinutes();
     var seconds = new Date(date).getSeconds() < 10 ? "0" + new Date(date).getSeconds() : new Date(date).getSeconds();
-	
-	return new Date(date).getFullYear() 
-			+ "-" 
-			+ ("0" + (new Date(date).getMonth() + 1)).slice(-2) 
-			+ "-" 
+
+	return new Date(date).getFullYear()
+			+ "-"
+			+ ("0" + (new Date(date).getMonth() + 1)).slice(-2)
+			+ "-"
 			+ ("0" + new Date(date).getUTCDate()).slice(-2)
 			+ " at "
 			+ hours

--- a/content/gitlab/widgets/pipeline-status/style.css
+++ b/content/gitlab/widgets/pipeline-status/style.css
@@ -6,6 +6,10 @@
 	background-color: #2e7d32;
 }
 
+.widget.gitlabPipelineStatus .success-with-warnings {
+	background-color: #daa520;
+}
+
 .widget.gitlabPipelineStatus .failed {
 	background-color: #d50000;
 	-webkit-animation: status-danger-background 1s infinite; /* Safari 4+ */
@@ -58,6 +62,13 @@
 .widget.gitlabPipelineStatus .value {
 	font-size: 22px;
 	margin-bottom: 10px;
+}
+
+.widget.gitlabPipelineStatus .failed-jobs {
+	font-size: 18px;
+	margin-bottom: 10px;
+	text-transform: none;
+	font-weight: 400;
 }
 
 .widget.gitlabPipelineStatus .time-table {


### PR DESCRIPTION
Improvements to GitLab pipeline status widget:
- new icons for canceled and skipped pipelines
![image](https://user-images.githubusercontent.com/55134804/195107471-0c256ce5-1b24-4462-a73e-1ea3ffe90185.png)![image](https://user-images.githubusercontent.com/55134804/195107697-2611b538-7c11-45e5-b0d6-85ccc58b226b.png)

- now showing the detailed status (success-with-warnings)
![image](https://user-images.githubusercontent.com/55134804/195107825-61e8786e-96c6-4a24-a225-62761153357c.png)

- ability to hide the timetable:  
![image](https://user-images.githubusercontent.com/55134804/195109061-c59e442e-fff1-4931-9cfe-87018c45a24f.png)

- ability to show the failed jobs:
![image](https://user-images.githubusercontent.com/55134804/195115633-666c5407-57fd-494f-9f43-68d723c3cbe3.png)![image](https://user-images.githubusercontent.com/55134804/195115735-d2d333c1-4a3f-4857-bbea-cbd30b604aec.png)
