### PR TITLE
Remove /jenkins from widgets HTML

### DIFF
--- a/content/jenkins/widgets/job-status/content.html
+++ b/content/jenkins/widgets/job-status/content.html
@@ -1,7 +1,7 @@
 {{^building}}
 <div class="fullwidget {{#success}}green{{/success}} {{#failure}}red{{/failure}} {{#unstable}}orange{{/unstable}}">
    <i class="fa-fix fa {{#success}}fa-thumbs-up{{/success}} {{#failure}}fa-thumbs-down{{/failure}} {{#unstable}}fa-exclamation-triangle{{/unstable}} icon-background"></i>
-   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/jenkins/job/{{SURI_JOB}}/" class="link" target="_blank">
+   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/job/{{SURI_JOB}}/" class="link" target="_blank">
       <div class="grid-stack-item-content-inner">
          <h1 class="title">{{SURI_JOB}}</h1>
          <div class="infos"><i class="fa fa-user" aria-hidden="true"></i> Last build by <span class="builtby value">{{builtBy}}</span></div>

--- a/content/jenkins/widgets/jobs-run-on-a-period/content.html
+++ b/content/jenkins/widgets/jobs-run-on-a-period/content.html
@@ -1,5 +1,5 @@
 <div class="fullwidget {{#ok}}green{{/ok}}{{^ok}}red{{/ok}}">
-   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/jenkins/{{view}}" class="link" target="_blank">
+   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/{{view}}" class="link" target="_blank">
       <div class="grid-stack-item-content-inner">
          {{#SURI_TITLE}}
          <h1 class="title">{{SURI_TITLE}}</h1>

--- a/content/jenkins/widgets/multiple-job-status/content.html
+++ b/content/jenkins/widgets/multiple-job-status/content.html
@@ -13,7 +13,7 @@
                 <ul class="jobs">
                     {{#job_critical}}
                         <li class="jobname">
-                            <a href="{{ WIDGET_CONFIG_JENKINS_URL }}/jenkins/job/{{jobName}}" target="_blank">
+                            <a href="{{ WIDGET_CONFIG_JENKINS_URL }}/job/{{jobName}}" target="_blank">
                                 <p>{{jobName}}, built by {{builder}}, status is: </p><h3>{{jobStatus}}</h3>
                             </a>
                         </li>
@@ -25,7 +25,7 @@
                 <ul class="jobs">
                     {{#job_unstable}}
                         <li class="jobname">
-                            <a href="{{ WIDGET_CONFIG_JENKINS_URL }}/jenkins/job/{{jobName}}" target="_blank">
+                            <a href="{{ WIDGET_CONFIG_JENKINS_URL }}/job/{{jobName}}" target="_blank">
                                 <p>{{jobName}}, built by {{builder}}, status is: </p><h3>{{jobStatus}}</h3>
                             </a>
                         </li>

--- a/content/jenkins/widgets/slave-status/content.html
+++ b/content/jenkins/widgets/slave-status/content.html
@@ -9,7 +9,7 @@
          <h2>{{nbDown}} slave(s) offline</h2>
          <ul class="hosts">
             {{#slave}}
-            <a href="{{WIDGET_CONFIG_JENKINS_URL}}/jenkins/computer/{{name}}/" target="_blank">
+            <a href="{{WIDGET_CONFIG_JENKINS_URL}}/computer/{{name}}/" target="_blank">
                <li class="hostname">
                   <h3>{{name}}</h3>
                </li>

--- a/content/jenkins/widgets/svn-git-jobs-run-on-a-period/content.html
+++ b/content/jenkins/widgets/svn-git-jobs-run-on-a-period/content.html
@@ -1,5 +1,5 @@
 <div class="fullwidget {{#ok}}green{{/ok}}{{^ok}}red{{/ok}}">
-   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/jenkins/{{view}}" class="link" target="_blank">
+   <a href="{{WIDGET_CONFIG_JENKINS_URL}}/{{view}}" class="link" target="_blank">
       <div class="grid-stack-item-content-inner">
          <h1 class="title">{{SURI_TITLE}}</h1>
          <div class="infos-container">

--- a/content/jenkins/widgets/waiting-queue/content.html
+++ b/content/jenkins/widgets/waiting-queue/content.html
@@ -1,4 +1,4 @@
-<a href="{{WIDGET_CONFIG_JENKINS_URL}}/jenkins/" target="_blank" class="link">
+<a href="{{WIDGET_CONFIG_JENKINS_URL}}/" target="_blank" class="link">
    <div class="fullwidget {{#ok}}green{{/ok}}{{^ok}}red{{/ok}}">
       <div class="grid-stack-item-content-inner">
          <h1 class="title">{{SURI_TITLE}}</h1>


### PR DESCRIPTION
Just a follow-up of https://github.com/michelin/suricate-widgets/commit/4fc07e5ad82c63465b0481ab7d8f7d507ddf2574 to remove `/jenkins` from HTML so the links to Jenkins on the widgets are working fine