### PR TITLE
sonar widget changes

### DIFF
--- a/content/sonar/widgets/project-metrics/content.html
+++ b/content/sonar/widgets/project-metrics/content.html
@@ -1,5 +1,5 @@
 <div class="grid-stack-item-content-inner">
-	<a href="{{WIDGET_CONFIG_SONAR_URL}}/sonar/dashboard/index?id={{SURI_PROJECT_KEY}}" target="_blank">
+	<a href="{{sonarConfigUrl}}/dashboard/index?id={{SURI_PROJECT_KEY}}" target="_blank">
 	   <div class="fullwidget">
 		  <div class="grid-stack-item-content-inner">
 			 <h1 class="title">{{SURI_TITLE}}</h1>

--- a/content/sonar/widgets/project-metrics/params.yml
+++ b/content/sonar/widgets/project-metrics/params.yml
@@ -41,3 +41,9 @@ widgetParams:
         jsKey: 'test_success_density'
         value: 'Unit test success density (%)'
     required: true
+  -
+    name: 'SURI_BRANCH'
+    description: 'Branch name'
+    type: TEXT
+    usageExample: 'My branch'
+    required: false

--- a/content/sonar/widgets/project-metrics/script.js
+++ b/content/sonar/widgets/project-metrics/script.js
@@ -17,9 +17,11 @@
 function run() {
 	var data = {};
 	data.results = [];
-	
+	// added to remove the trailing slash from the URL if present
+	data.sonarConfigUrl = (WIDGET_CONFIG_SONAR_URL) ? WIDGET_CONFIG_SONAR_URL.replace(/\/+$/, '') : WIDGET_CONFIG_SONAR_URL;
+
 	var response = JSON.parse(
-					Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/measures/component?component=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
+					Packages.get(data.sonarConfigUrl + "/api/measures/component?" + (SURI_BRANCH != null ? "branch=" + SURI_BRANCH +"&" : "") +"component=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
 					"Authorization", "Basic " + Packages.btoa(WIDGET_CONFIG_SONAR_TOKEN + ":")));
 
 	if (response && response.component && response.component.measures && response.component.measures.length > 0) {

--- a/content/sonar/widgets/projects-activity-by-analyse/script.js
+++ b/content/sonar/widgets/projects-activity-by-analyse/script.js
@@ -8,6 +8,8 @@ function run() {
 	var projectsAndAnalysesQuantity = {};
 	var pageSize = 500;
 	var projectPage = 1;
+	// added to remove the trailing slash from the URL if present
+	data.sonarConfigUrl = (WIDGET_CONFIG_SONAR_URL) ? WIDGET_CONFIG_SONAR_URL.replace(/\/+$/, '') : WIDGET_CONFIG_SONAR_URL;
 	
 	if (SURI_PERIOD) {
 		var numberOfPeriods = 1;
@@ -38,7 +40,7 @@ function run() {
 	projectsNamesOrKeys.forEach(function(projectNameOrKey) {
 		var projects = [];
 		
-		var response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/components/search?" 
+		var response = JSON.parse(Packages.get(data.sonarConfigUrl + "/api/components/search?" 
 						+ "qualifiers=TRK"
 						+ "&q=" + projectNameOrKey
 						+ "&ps=" + pageSize
@@ -51,8 +53,8 @@ function run() {
 			while (response.paging.total > response.paging.pageIndex * response.paging.pageSize) {
 				projectPage++;
 				
-				response = JSON.parse(Packages.get(WIDGET_CONFIG_SONAR_URL + "/api/components/search?"
-							+ "qualifiers=TRK"
+				response = JSON.parse(Packages.get(data.sonarConfigUrl + "/api/components/search?"
+							+ "qualifiers=TRK"	
 							+ "&q=" + projectNameOrKey
 							+ "&ps=" + pageSize 
 							+ "&p=" + projectPage,
@@ -66,7 +68,7 @@ function run() {
 					projectsAndAnalysesQuantity[projectNameOrKey] = 0;
 				}
 				
-				var projectAnalysesURL = WIDGET_CONFIG_SONAR_URL + "/api/project_analyses/search?project=" + project.key
+				var projectAnalysesURL = data.sonarConfigUrl + "/api/project_analyses/search?project=" + project.key
 											+ "&ps" + pageSize + "&p=1";
 				
 				if (data.fromDate) {


### PR DESCRIPTION
- Added branch name for project-metrics widget.
- Trailing backslash for URL has been trimmed.
- Removed /sonar from the content.html to redirect to correct project key as expected.