### PR TITLE
Added ability to use gitlab project / group path

### DIFF
--- a/content/gitlab/widgets/commits-timeline/params.yml
+++ b/content/gitlab/widgets/commits-timeline/params.yml
@@ -1,9 +1,9 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project IDs, separated by a comma'
+    description: 'Project IDs/paths, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_PERIOD
@@ -11,16 +11,12 @@ widgetParams:
     usageTooltip: 'Select a period.'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
-
     required: false
   -
     name: SURI_NUMBER_OF_PERIOD
@@ -49,4 +45,3 @@ widgetParams:
         value: 10
     usageExample: 1
     required: false
-

--- a/content/gitlab/widgets/commits-timeline/script.js
+++ b/content/gitlab/widgets/commits-timeline/script.js
@@ -39,7 +39,7 @@ function run() {
 	data.projectNames = '';
 
 	data.fromDate = computeStartDate();
-	var projectIDs = SURI_PROJECT.split(",");
+	var projectIDs = SURI_PROJECT.split(",").replaceAll("/", "%2F");
 	var labels = [];
 
 	projectIDs.forEach(function(id, index) {

--- a/content/gitlab/widgets/count-issues/params.yml
+++ b/content/gitlab/widgets/count-issues/params.yml
@@ -1,7 +1,7 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project ID'
+    description: 'Project ID or path'
     type: TEXT
     usageExample: '1234'
     required: true
@@ -11,13 +11,10 @@ widgetParams:
     type: COMBO
     defaultValue: 'all'
     possibleValuesMap:
-      -
-        jsKey: all
+      - jsKey: all
         value: All
-      -
-        jsKey: opened
+      - jsKey: opened
         value: Opened
-      -
-        jsKey: closed
+      - jsKey: closed
         value: Closed
     required: true

--- a/content/gitlab/widgets/count-issues/script.js
+++ b/content/gitlab/widgets/count-issues/script.js
@@ -19,34 +19,35 @@ function run() {
 	var data = {};
 	var issues = [];
 	var page = 1;
-	
+	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
+
 	data.project = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
 	var response = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 	issues = issues.concat(response);
-		
+
 	while (response && response.length > 0 && response.length === perPage) {
 		page++;
-		
+
 		response = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-		
+			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+
 		issues = issues.concat(response);
 	}
-	
+
 	data.numberOfIssues = issues.length;
-	
+
 	if (SURI_PREVIOUS && JSON.parse(SURI_PREVIOUS).numberOfIssues) {
 		data.evolution = ((data.numberOfIssues - JSON.parse(SURI_PREVIOUS).numberOfIssues) * 100 / JSON.parse(SURI_PREVIOUS).numberOfIssues).toFixed(1);
 		data.arrow = data.evolution == 0 ? '' : (data.evolution > 0 ? "up" : "down");
 	}
-	
+
 	if (SURI_ISSUES_STATE != 'all') {
 		data.issuesState = SURI_ISSUES_STATE;
 	}
-	
+
 	return JSON.stringify(data);
 }

--- a/content/gitlab/widgets/count-merge-requests/params.yml
+++ b/content/gitlab/widgets/count-merge-requests/params.yml
@@ -1,7 +1,7 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project ID'
+    description: 'Project ID or path'
     type: TEXT
     usageExample: '1234'
     required: true
@@ -11,19 +11,14 @@ widgetParams:
     type: COMBO
     defaultValue: 'all'
     possibleValuesMap:
-      -
-        jsKey: all
+      - jsKey: all
         value: All
-      -
-        jsKey: opened
+      - jsKey: opened
         value: Opened
-      -
-        jsKey: closed
+      - jsKey: closed
         value: Closed
-      -
-        jsKey: locked
+      - jsKey: locked
         value: Locked
-      -
-        jsKey: merged
+      - jsKey: merged
         value: Merged
     required: true

--- a/content/gitlab/widgets/count-merge-requests/script.js
+++ b/content/gitlab/widgets/count-merge-requests/script.js
@@ -19,34 +19,35 @@ function run() {
 	var data = {};
 	var mergeRequests = [];
 	var page = 1;
-	
+	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
+
 	data.project = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
 	var response = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 	mergeRequests = mergeRequests.concat(response);
-		
+
 	while (response && response.length > 0 && response.length === perPage) {
 		page++;
-		
+
 		response = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-		
+			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+
 		mergeRequests = mergeRequests.concat(response);
 	}
-	
+
 	data.numberOfMRs = mergeRequests.length;
-	
+
 	if (SURI_PREVIOUS && JSON.parse(SURI_PREVIOUS).numberOfMRs) {
 		data.evolution = ((data.numberOfMRs - JSON.parse(SURI_PREVIOUS).numberOfMRs) * 100 / JSON.parse(SURI_PREVIOUS).numberOfMRs).toFixed(1);
 		data.arrow = data.evolution == 0 ? '' : (data.evolution > 0 ? "up" : "down");
 	}
-	
+
 	if (SURI_MR_STATE != 'all') {
 		data.mrsState = SURI_MR_STATE;
 	}
-	
+
 	return JSON.stringify(data);
 }

--- a/content/gitlab/widgets/count-releases/params.yml
+++ b/content/gitlab/widgets/count-releases/params.yml
@@ -1,9 +1,9 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project IDs, separated by a comma'
+    description: 'Project IDs/paths, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_AGGREGATE_BY
@@ -11,11 +11,9 @@ widgetParams:
     usageTooltip: 'Releases aggregated by date/tag name will be counted as one release if they have the same date/tag name'
     type: MULTIPLE
     possibleValuesMap:
-      -
-        jsKey: AGGREGATE_BY_DATE
+      - jsKey: AGGREGATE_BY_DATE
         value: 'Date'
-      -
-        jsKey: AGGREGATE_BY_TAG_NAME
+      - jsKey: AGGREGATE_BY_TAG_NAME
         value: 'Tag name'
     required: false
   -
@@ -31,17 +29,13 @@ widgetParams:
     usageTooltip: 'If defined, it is not necessary to define a precise date. The precise date takes priority over the period.'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
-      -
-        jsKey: Day
+      - jsKey: Day
         value: Day
     required: false
   -

--- a/content/gitlab/widgets/count-releases/script.js
+++ b/content/gitlab/widgets/count-releases/script.js
@@ -28,7 +28,7 @@ function run() {
 
 	data.fromDate = computeStartDate();
 
-	var projectIDs = SURI_PROJECT.split(",");
+	var projectIDs = SURI_PROJECT.split(",").replaceAll("/", "%2F");
 
 	projectIDs.forEach(function(id) {
 		data.projects += JSON.parse(

--- a/content/gitlab/widgets/count-users/params.yml
+++ b/content/gitlab/widgets/count-users/params.yml
@@ -17,15 +17,13 @@ widgetParams:
     type: TEXT
     usageExample: 'Jack'
     required: false
-  - 
+  -
     name: 'SURI_STATE'
     description: 'Filter users by state'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: active
+      - jsKey: active
         value: active
-      -
-        jsKey: blocked
+      - jsKey: blocked
         value: blocked
     required: false

--- a/content/gitlab/widgets/files-extensions-repartition/params.yml
+++ b/content/gitlab/widgets/files-extensions-repartition/params.yml
@@ -7,7 +7,7 @@ widgetParams:
     required: true
   -
     name: SURI_PROJECT
-    description: 'Project ID'
+    description: 'Project ID or path'
     type: TEXT
     usageExample: '1234'
     required: true
@@ -17,13 +17,10 @@ widgetParams:
     type: COMBO
     defaultValue: 'pie'
     possibleValuesMap:
-      -
-        jsKey: pie
+      - jsKey: pie
         value: Pie
-      -
-        jsKey: horizontalBar
+      - jsKey: horizontalBar
         value: Horizontal bar
-      -
-        jsKey: bar
+      - jsKey: bar
         value: Vertical bar
     required: true

--- a/content/gitlab/widgets/files-extensions-repartition/script.js
+++ b/content/gitlab/widgets/files-extensions-repartition/script.js
@@ -13,7 +13,7 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-  
+
 function run() {
 	var data = {};
 
@@ -21,24 +21,25 @@ function run() {
 	data.datapie = [];
 	data.colors = [];
 	data.border = [];
+	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
 
-	var json = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/languages", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+	var json = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/languages", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 	if (json) {
 		data.labels = Object.keys(json);
 		data.datapie = Object.keys(json).map(function(key){return json[key]})
-		
+
 		data.labels.forEach(function(label) {
 			data.colors.push(stringToColour("COLOR" + label));
 			data.border.push("#607D8B");
 		});
-		
+
 		data.colors = JSON.stringify(data.colors);
 		data.labels = JSON.stringify(data.labels);
 		data.datapie = JSON.stringify(data.datapie);
 		data.border = JSON.stringify(data.border);
 	}
-	
+
 	return JSON.stringify(data);
 }
 

--- a/content/gitlab/widgets/issues-timeline/params.yml
+++ b/content/gitlab/widgets/issues-timeline/params.yml
@@ -12,9 +12,9 @@ widgetParams:
         value: Project ID
   -
     name: SURI_ID
-    description: 'Project IDs or Group IDs depending upon SURI_ID_TYPE selection, separated by a comma'
+    description: 'Project IDs/paths or Group IDs/paths depending upon SURI_ID_TYPE selection, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_PERIOD
@@ -22,14 +22,11 @@ widgetParams:
     usageTooltip: 'Select a period.'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
 
     required: false
@@ -66,13 +63,10 @@ widgetParams:
     type: COMBO
     defaultValue: 'all'
     possibleValuesMap:
-      -
-        jsKey: all
+      - jsKey: all
         value: All
-      -
-        jsKey: opened
+      - jsKey: opened
         value: Opened
-      -
-        jsKey: closed
+      - jsKey: closed
         value: Closed
     required: true

--- a/content/gitlab/widgets/issues-timeline/script.js
+++ b/content/gitlab/widgets/issues-timeline/script.js
@@ -40,7 +40,7 @@ function run() {
 	data.fromDate = computeStartDate();
 	var projectOrGroupType = computeIDType();
 
-	var projectOrGroupIDs = SURI_ID.split(",");
+	var projectOrGroupIDs = SURI_ID.split(",").replaceAll("/", "%2F");
 	data.issueState = SURI_ISSUES_STATE;
 	var labels = [];
 

--- a/content/gitlab/widgets/merge-requests-timeline/params.yml
+++ b/content/gitlab/widgets/merge-requests-timeline/params.yml
@@ -11,23 +11,20 @@ widgetParams:
         value: Project ID
   -
     name: SURI_ID
-    description: 'Project IDs or Group IDs depending upon SURI_ID_TYPE selection, separated by a comma'
+    description: 'Project IDs/paths or Group IDs/paths depending upon SURI_ID_TYPE selection, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_PERIOD
     description: 'Retrieve the merge requests from a period'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
     required: false
   -

--- a/content/gitlab/widgets/merge-requests-timeline/script.js
+++ b/content/gitlab/widgets/merge-requests-timeline/script.js
@@ -43,7 +43,7 @@ function run() {
 	data.fromDate = computeStartDate();
 	var projectOrGroupType = computeIDType();
 
-	var projectOrGroupIDs = SURI_ID.split(",");
+	var projectOrGroupIDs = SURI_ID.split(",").replaceAll("/", "%2F");
 	data.mrsState = SURI_MR_STATE;
 
 	projectOrGroupIDs.forEach(function(id, index) {

--- a/content/gitlab/widgets/pipeline-status/params.yml
+++ b/content/gitlab/widgets/pipeline-status/params.yml
@@ -1,7 +1,7 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project ID'
+    description: 'Project ID or path'
     type: TEXT
     usageExample: '1234'
     required: true

--- a/content/gitlab/widgets/pipeline-status/script.js
+++ b/content/gitlab/widgets/pipeline-status/script.js
@@ -16,11 +16,12 @@
 
 function run() {
 	var data = {};
+	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
 
 	data.project = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
-	var url = WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines";
+	var url = WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/pipelines";
 
 	if (SURI_PROJECT_BRANCH) {
 		url += "?ref=" + SURI_PROJECT_BRANCH;
@@ -30,7 +31,7 @@ function run() {
 
 	if (pipelines && pipelines.length > 0) {
 		var pipeline = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines/" + pipelines[0].id, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/pipelines/" + pipelines[0].id, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 		data.status = pipeline.detailed_status.group;
 		data.name = pipeline.user.name;
@@ -57,7 +58,7 @@ function run() {
 		if ((SHOW_FAILED_JOBS && SHOW_FAILED_JOBS === 'true') && (data.status === 'success-with-warnings' || data.status === 'failed')) {
 			data.showFailedJobs = SHOW_FAILED_JOBS;
 			var failed_jobs = JSON.parse(
-				Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/pipelines/" + pipeline.id + "/jobs?scope=failed&per_page=100&page=1", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+				Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/pipelines/" + pipeline.id + "/jobs?scope=failed&per_page=100&page=1", "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 				data.failed_jobs = "";
 			for (var i = 0; i < failed_jobs.length; i++) {
 				data.failed_jobs = data.failed_jobs + failed_jobs[i].name + ", ";

--- a/content/gitlab/widgets/projects-activity-by-event/params.yml
+++ b/content/gitlab/widgets/projects-activity-by-event/params.yml
@@ -13,9 +13,9 @@ widgetParams:
     required: false
   -
     name: SURI_PROJECT
-    description: 'Projects IDs, separated by a comma'
+    description: 'Projects IDs/paths, separated by a comma'
     type: TEXT
-    usageExample: '1234,4567'
+    usageExample: '1234,mygroup/myproject'
     required: false
   -
     name: 'SURI_DATE'
@@ -30,44 +30,31 @@ widgetParams:
     type: COMBO
     defaultValue: 'all'
     possibleValuesMap:
-      -
-        jsKey: all
+      - jsKey: all
         value: All
-      -
-        jsKey: approved
+      - jsKey: approved
         value: Approved
-      -
-        jsKey: created
+      - jsKey: created
         value: Created
-      -
-        jsKey: updated
+      - jsKey: updated
         value: Updated
-      -
-        jsKey: closed
+      - jsKey: closed
         value: Closed
-      -
-        jsKey: reopened
+      - jsKey: reopened
         value: Reopened
-      -
-        jsKey: pushed
+      - jsKey: pushed
         value: Pushed
-      -
-        jsKey: commented
+      - jsKey: commented
         value: Commented
-      -
-        jsKey: merged
+      - jsKey: merged
         value: Merged
-      -
-        jsKey: joined
+      - jsKey: joined
         value: Joined
-      -
-        jsKey: left
+      - jsKey: left
         value: Left
-      -
-        jsKey: destroyed
+      - jsKey: destroyed
         value: Destroyed
-      -
-        jsKey: expired
+      - jsKey: expired
         value: Expired
     required: true
   -
@@ -76,29 +63,21 @@ widgetParams:
     type: COMBO
     defaultValue: 'all'
     possibleValuesMap:
-      -
-        jsKey: all
+      - jsKey: all
         value: All
-      -
-        jsKey: issue
+      - jsKey: issue
         value: Issue
-      -
-        jsKey: milestone
+      - jsKey: milestone
         value: Milestone
-      -
-        jsKey: merge_request
+      - jsKey: merge_request
         value: Merge request
-      -
-        jsKey: note
+      - jsKey: note
         value: Note
-      -
-        jsKey: project
+      - jsKey: project
         value: Project
-      -
-        jsKey: snippet
+      - jsKey: snippet
         value: Snippet
-      -
-        jsKey: user
+      - jsKey: user
         value: User
     required: true
   -
@@ -107,13 +86,10 @@ widgetParams:
     type: COMBO
     defaultValue: 'pie'
     possibleValuesMap:
-      -
-        jsKey: pie
+      - jsKey: pie
         value: Pie
-      -
-        jsKey: horizontalBar
+      - jsKey: horizontalBar
         value: Horizontal bar
-      -
-        jsKey: bar
+      - jsKey: bar
         value: Vertical bar
     required: true

--- a/content/gitlab/widgets/projects-activity-by-event/script.js
+++ b/content/gitlab/widgets/projects-activity-by-event/script.js
@@ -13,7 +13,7 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-  
+
 function run() {
 	var data = {};
 
@@ -22,42 +22,42 @@ function run() {
 	data.colors = [];
 
 	var urlParameters;
-	
+
 	// To retrieve the events of today, GitLab seems to require the date of yesterday
 	data.fromDate = new Date().getFullYear() + "-" + ("0" + (new Date().getMonth() + 1)).slice(-2) + "-" + ("0" + new Date().getUTCDate()).slice(-2);
-	
-	var today = new Date();		
+
+	var today = new Date();
 	today.setDate(today.getDate() - 1);
 	var todayForGitLabString = today.getFullYear() + "-" + ("0" + (today.getMonth() + 1)).slice(-2) + "-" + ("0" + today.getUTCDate()).slice(-2);
-	
+
 	if (SURI_DATE && SURI_DATE !== null) {
 		data.fromDate = SURI_DATE.slice(4) + "-" + SURI_DATE.slice(2, 4) + "-" + SURI_DATE.slice(0, 2);
 		var givenDate = new Date(data.fromDate);
 		givenDate.setDate(givenDate.getDate() - 1);
-		
+
 		todayForGitLabString = givenDate.getFullYear() + "-" + ("0" + (givenDate.getMonth() + 1)).slice(-2) + "-" + ("0" + givenDate.getUTCDate()).slice(-2);
 	}
-		
+
 	var urlParameters = "?per_page=100&after=" + todayForGitLabString;
-	
+
 	if (SURI_ACTION_TYPE && SURI_ACTION_TYPE !== null) {
 		data.action = SURI_ACTION_TYPE.charAt(0).toUpperCase() + SURI_ACTION_TYPE.substring(1).toLowerCase();
 		if (SURI_ACTION_TYPE !== 'all') {
 			urlParameters += "&action=" + SURI_ACTION_TYPE;
 		}
 	}
-	
+
 	if (SURI_TARGET_TYPE && SURI_TARGET_TYPE !== null) {
 		data.target = SURI_TARGET_TYPE.charAt(0).toUpperCase() + SURI_TARGET_TYPE.substring(1).toLowerCase();
 		if (SURI_TARGET_TYPE !== 'all') {
 			urlParameters += "&target_type=" + SURI_TARGET_TYPE;
 		}
 	}
-		
+
 	var projects = [];
 	if (SURI_PROJECT && SURI_PROJECT !== null) {
-		projectIds = SURI_PROJECT.split(",");
-		
+		projectIds = SURI_PROJECT.split(",").replaceAll("/", "%2F");
+
 		projectIds.forEach(function(projectId) {
 			projects.push(JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectId, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)));
 		});
@@ -67,17 +67,17 @@ function run() {
 		if (SURI_TOP && SURI_TOP !== null) {
 			numberOfProjects = SURI_TOP;
 		}
-		
+
 		projects = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects?order_by=last_activity_at&per_page=" + numberOfProjects, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 	}
-	
+
 	if (projects && projects !== null && projects.length > 0) {
 		projects.forEach(function(project) {
 			data.labels.push(project.name);
 			data.colors.push(stringToColour(project.name));
 
 			var events = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + project.id + "/events" + urlParameters, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-			
+
 			if (events && events !== null && events.length > 0) {
 				data.datapie.push(events.length);
 			} else {
@@ -85,7 +85,7 @@ function run() {
 			}
 		});
 	}
-		
+
 	data.colors = JSON.stringify(data.colors);
 	data.labels = JSON.stringify(data.labels);
 	data.datapie = JSON.stringify(data.datapie);

--- a/content/gitlab/widgets/releases-by-projects/params.yml
+++ b/content/gitlab/widgets/releases-by-projects/params.yml
@@ -1,9 +1,9 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project IDs, separated by a comma'
+    description: 'Project IDs/paths, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_AGGREGATE_BY
@@ -11,11 +11,9 @@ widgetParams:
     usageTooltip: 'Releases aggregated by date/tag name will be counted as one release if they have the same date/tag name'
     type: MULTIPLE
     possibleValuesMap:
-      -
-        jsKey: AGGREGATE_BY_DATE
+      - jsKey: AGGREGATE_BY_DATE
         value: 'Date'
-      -
-        jsKey: AGGREGATE_BY_TAG_NAME
+      - jsKey: AGGREGATE_BY_TAG_NAME
         value: 'Tag name'
     required: false
   -
@@ -31,17 +29,13 @@ widgetParams:
     usageTooltip: 'If defined, it is not necessary to define a precise date. The precise date takes priority over the period.'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
-      -
-        jsKey: Day
+      - jsKey: Day
         value: Day
     required: false
   -
@@ -56,10 +50,8 @@ widgetParams:
     type: COMBO
     defaultValue: 'NUMBER_OF_RELEASES'
     possibleValuesMap:
-      -
-        jsKey: PROJECT_NAME
+      - jsKey: PROJECT_NAME
         value: Name of the projects
-      -
-        jsKey: NUMBER_OF_RELEASES
+      - jsKey: NUMBER_OF_RELEASES
         value: Number of releases
     required: true

--- a/content/gitlab/widgets/releases-by-projects/script.js
+++ b/content/gitlab/widgets/releases-by-projects/script.js
@@ -26,7 +26,7 @@ function run() {
 
 	data.fromDate = computeStartDate();
 
-	var projectIDs = SURI_PROJECT.split(",");
+	var projectIDs = SURI_PROJECT.split(",").replaceAll("/", "%2F");
 
 	projectIDs.forEach(function(id) {
 		releases = []

--- a/content/gitlab/widgets/releases-timeline/params.yml
+++ b/content/gitlab/widgets/releases-timeline/params.yml
@@ -1,9 +1,9 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project IDs, separated by a comma'
+    description: 'Project IDs/paths, separated by a comma'
     type: TEXT
-    usageExample: '1234,5678'
+    usageExample: '1234,mygroup/myproject'
     required: true
   -
     name: SURI_DATE
@@ -18,17 +18,13 @@ widgetParams:
     usageTooltip: 'If defined, it is not necessary to define a precise date. The precise date takes priority over the period.'
     type: COMBO
     possibleValuesMap:
-      -
-        jsKey: Year
+      - jsKey: Year
         value: Year
-      -
-        jsKey: Month
+      - jsKey: Month
         value: Month
-      -
-        jsKey: Week
+      - jsKey: Week
         value: Week
-      -
-        jsKey: Day
+      - jsKey: Day
         value: Day
     required: false
   -

--- a/content/gitlab/widgets/releases-timeline/script.js
+++ b/content/gitlab/widgets/releases-timeline/script.js
@@ -25,7 +25,7 @@ function run() {
 
 	data.fromDate = computeStartDate();
 
-	var projectIDs = SURI_PROJECT.split(",");
+	var projectIDs = SURI_PROJECT.split(",").replaceAll("/", "%2F");
 
 	projectIDs.forEach(function(id, index) {
 		releases = [];

--- a/content/gitlab/widgets/user-roles-project-distribution/params.yml
+++ b/content/gitlab/widgets/user-roles-project-distribution/params.yml
@@ -1,7 +1,7 @@
 widgetParams:
   -
     name: SURI_PROJECT
-    description: 'Project ID'
+    description: 'Project ID or path'
     type: TEXT
     usageExample: '1234'
     required: true

--- a/content/gitlab/widgets/user-roles-project-distribution/script.js
+++ b/content/gitlab/widgets/user-roles-project-distribution/script.js
@@ -24,9 +24,10 @@ function run() {
 	data.maintainer = 0;
 	data.owner = 0;
 	data.total = 0;
+	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
 
-	var project = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-	var members = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/members/all?per_page=100&page=" + page, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+	var project = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+	var members = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/members/all?per_page=100&page=" + page, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 	if (members && members.length > 0) {
 		data.minimalAccess = countMembersOfRole(members, 5);
@@ -41,7 +42,7 @@ function run() {
 	while (members && members !== null && members.length > 0) {
 		page++;
 
-		members = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + SURI_PROJECT + "/members/all?per_page=100&page=" + page, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+		members = JSON.parse(Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/members/all?per_page=100&page=" + page, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
 
 		if (members && members.length > 0) {
 			data.minimalAccess = data.minimalAccess + countMembersOfRole(members, 5);


### PR DESCRIPTION
Hello @loicgreffier,

Added this in order to use GitLab project path instead of project ID, based on GitLab documentation https://docs.gitlab.com/ee/api/rest/index.html#namespaced-path-encoding

![image](https://github.com/michelin/suricate-widgets/assets/55134804/d766e780-ec22-41c2-ab0f-33f31376b78b)

To be honest I have not tested them all, but it seems to work fine, example for pipeline-status widget:

![image](https://github.com/michelin/suricate-widgets/assets/55134804/ac102c59-ff39-4ab5-bb99-2bfe0388d71b)