### PR TITLE
Added ability to use PR with sonar widgets

### DIFF
--- a/content/sonar/widgets/issues-graph/params.yml
+++ b/content/sonar/widgets/issues-graph/params.yml
@@ -41,7 +41,12 @@ widgetParams:
       - jsKey: 'bar'
         value: 'Vertical bar'
   - name: 'SURI_BRANCH'
-    description: 'Branch name'
+    description: 'Branch name, if user provides both branch and pull request, the branch takes precedence.'
     type: TEXT
     usageExample: 'My branch'
+    required: false
+  - name: 'SURI_PULL_REQUEST'
+    description: 'Merge/Pull Request Number'
+    type: TEXT
+    usageExample: '111'
     required: false

--- a/content/sonar/widgets/issues-graph/script.js
+++ b/content/sonar/widgets/issues-graph/script.js
@@ -191,7 +191,7 @@ function getIssuesFromSonarqube(
   var sonarApiUrl =
     sonarUrl +
     "/api/measures/search_history?" +
-    (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : "") +
+    (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : (SURI_PULL_REQUEST != null ? "pullRequest=" + SURI_PULL_REQUEST + "&" : "")) +
     "metrics=bugs,vulnerabilities,code_smells&component=" +
     projectKeys +
     "&ps=" +

--- a/content/sonar/widgets/lines-of-code-timeline/params.yml
+++ b/content/sonar/widgets/lines-of-code-timeline/params.yml
@@ -25,7 +25,12 @@ widgetParams:
     defaultValue: 6
     required: false
   - name: 'SURI_BRANCH'
-    description: 'Branch name'
+    description: 'Branch name, if user provides both branch and pull request, the branch takes precedence.'
     type: TEXT
     usageExample: 'My branch'
+    required: false
+  - name: 'SURI_PULL_REQUEST'
+    description: 'Merge/Pull Request Number'
+    type: TEXT
+    usageExample: '111'
     required: false

--- a/content/sonar/widgets/lines-of-code-timeline/script.js
+++ b/content/sonar/widgets/lines-of-code-timeline/script.js
@@ -180,7 +180,7 @@ function getLinesOfCodeFromSonarQube(
   var sonarApiUrl =
     sonarUrl +
     "/api/measures/search_history?" +
-    (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : "") +
+    (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : (SURI_PULL_REQUEST != null ? "pullRequest=" + SURI_PULL_REQUEST + "&" : "")) +
     "metrics=ncloc&component=" +
     projectKeys +
     "&ps=" +

--- a/content/sonar/widgets/project-metrics/params.yml
+++ b/content/sonar/widgets/project-metrics/params.yml
@@ -43,7 +43,13 @@ widgetParams:
     required: true
   -
     name: 'SURI_BRANCH'
-    description: 'Branch name'
+    description: 'Branch name, if user provides both branch and pull request, the branch takes precedence.'
     type: TEXT
     usageExample: 'My branch'
     required: false
+  -
+      name: 'SURI_PULL_REQUEST'
+      description: 'Merge/Pull Request Number'
+      type: TEXT
+      usageExample: '111'
+      required: false

--- a/content/sonar/widgets/project-metrics/script.js
+++ b/content/sonar/widgets/project-metrics/script.js
@@ -21,8 +21,8 @@ function run() {
 	data.sonarConfigUrl = (WIDGET_CONFIG_SONAR_URL) ? WIDGET_CONFIG_SONAR_URL.replace(/\/+$/, '') : WIDGET_CONFIG_SONAR_URL;
 
 	var response = JSON.parse(
-					Packages.get(data.sonarConfigUrl + "/api/measures/component?" + (SURI_BRANCH != null ? "branch=" + SURI_BRANCH +"&" : "") +"component=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
-					"Authorization", "Basic " + Packages.btoa(WIDGET_CONFIG_SONAR_TOKEN + ":")));
+    	    Packages.get(data.sonarConfigUrl + "/api/measures/component?" + (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : (SURI_PULL_REQUEST != null ? "pullRequest=" + SURI_PULL_REQUEST + "&" : ""))  +"component=" + SURI_PROJECT_KEY + "&additionalFields=metrics&metricKeys=" + SURI_METRICS,
+    		"Authorization", "Basic " + Packages.btoa(WIDGET_CONFIG_SONAR_TOKEN + ":")));
 
 	if (response && response.component && response.component.measures && response.component.measures.length > 0) {
 		response.component.measures.forEach(function(measure) {

--- a/content/sonar/widgets/project-vulnerability-graph/params.yml
+++ b/content/sonar/widgets/project-vulnerability-graph/params.yml
@@ -41,7 +41,12 @@ widgetParams:
       - jsKey: 'bar'
         value: 'Vertical bar'
   - name: 'SURI_BRANCH'
-    description: 'Branch name'
+    description: 'Branch name, if user provides both branch and pull request, the branch takes precedence.'
     type: TEXT
     usageExample: 'My branch'
+    required: false
+  - name: 'SURI_PULL_REQUEST'
+    description: 'Merge/Pull Request Number'
+    type: TEXT
+    usageExample: '111'
     required: false

--- a/content/sonar/widgets/project-vulnerability-graph/script.js
+++ b/content/sonar/widgets/project-vulnerability-graph/script.js
@@ -257,7 +257,7 @@ function getIssuesFromSonarqube(
 ) {
   var sonarApiUrl =
     sonarUrl +
-    "/api/issues/search?"+ (SURI_BRANCH != null ? "branch=" + SURI_BRANCH +"&" : "") +
+    "/api/issues/search?"+ (SURI_BRANCH != null ? "branch=" + SURI_BRANCH + "&" : (SURI_PULL_REQUEST != null ? "pullRequest=" + SURI_PULL_REQUEST + "&" : "")) +
     "types=VULNERABILITY&componentKeys=" +
     projectKeys +
     "&ps=" +


### PR DESCRIPTION
hello @loicgreffier,

We update the existing Sonar widgets for them to work with pull requests.

Even though pull requests are not supposed to be long-living, some of our users were interested in being able to follow these from Suricate.

If the user provides both a branch and a pull request, the branch takes precedence.

Since it is a quick improvement, we wanted to share it with you 😄 
