### PR TITLE
Improved API call for count issue and count MR on Gitlab

### DIFF
--- a/content/gitlab/widgets/count-issues/script.js
+++ b/content/gitlab/widgets/count-issues/script.js
@@ -15,30 +15,17 @@
   */
 
 function run() {
-	var perPage = 100;
+
 	var data = {};
-	var issues = [];
-	var page = 1;
 	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
 
 	data.project = JSON.parse(
 		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
 	var response = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/issues?state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN, "X-Total"));
 
-	issues = issues.concat(response);
-
-	while (response && response.length > 0 && response.length === perPage) {
-		page++;
-
-		response = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/issues?per_page=" + perPage + "&page=" + page + "&state=" + SURI_ISSUES_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-
-		issues = issues.concat(response);
-	}
-
-	data.numberOfIssues = issues.length;
+	data.numberOfIssues = response;
 
 	if (SURI_PREVIOUS && JSON.parse(SURI_PREVIOUS).numberOfIssues) {
 		data.evolution = ((data.numberOfIssues - JSON.parse(SURI_PREVIOUS).numberOfIssues) * 100 / JSON.parse(SURI_PREVIOUS).numberOfIssues).toFixed(1);

--- a/content/gitlab/widgets/count-merge-requests/script.js
+++ b/content/gitlab/widgets/count-merge-requests/script.js
@@ -15,31 +15,16 @@
   */
 
 function run() {
-	var perPage = 100;
 	var data = {};
-	var mergeRequests = [];
-	var page = 1;
 	var projectID = SURI_PROJECT.replaceAll("/", "%2F");
 
 	data.project = JSON.parse(
 		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN)).name;
 
 	var response = JSON.parse(
-		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
+		Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/merge_requests?state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN, "X-Total"));
 
-	mergeRequests = mergeRequests.concat(response);
-
-	while (response && response.length > 0 && response.length === perPage) {
-		page++;
-
-		response = JSON.parse(
-			Packages.get(WIDGET_CONFIG_GITLAB_URL + "/api/v4/projects/" + projectID + "/merge_requests?per_page=" + perPage + "&page=" + page + "&state=" + SURI_MR_STATE, "PRIVATE-TOKEN", WIDGET_CONFIG_GITLAB_TOKEN));
-
-		mergeRequests = mergeRequests.concat(response);
-	}
-
-	data.numberOfMRs = mergeRequests.length;
-
+	data.numberOfMRs = response;
 	if (SURI_PREVIOUS && JSON.parse(SURI_PREVIOUS).numberOfMRs) {
 		data.evolution = ((data.numberOfMRs - JSON.parse(SURI_PREVIOUS).numberOfMRs) * 100 / JSON.parse(SURI_PREVIOUS).numberOfMRs).toFixed(1);
 		data.arrow = data.evolution == 0 ? '' : (data.evolution > 0 ? "up" : "down");


### PR DESCRIPTION
Hello @loicgreffier,

We improve the request for the project's count of issues or MR. 
We face some issues with projects that have a lot of those and we want to use the header (x-Total) instead of using pagination:

(MR)
![image](https://github.com/michelin/suricate-widgets/assets/121865194/2a268bf6-f661-42dd-be67-d8636ac942fc)

(Issue)
![image](https://github.com/michelin/suricate-widgets/assets/121865194/29cf0edf-e5b0-4a34-9c42-118fa9673969)

Suricate:

![image](https://github.com/michelin/suricate-widgets/assets/121865194/fb38e52e-c4d2-4723-9732-d3cb3a1e8348)

Please have a look 😊
